### PR TITLE
allow specifying root with GO_SKIP_ROOT

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -13,7 +14,7 @@ type skipConfig struct {
 	Packages map[string]map[string]bool `json:"packages"`
 }
 
-func readSkipConfig(file string) (_ *skipConfig, err error) {
+func readSkipConfig(file string, rootPkg string) (_ *skipConfig, err error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -26,6 +27,9 @@ func readSkipConfig(file string) (_ *skipConfig, err error) {
 		Packages: make(map[string]map[string]bool),
 	}
 	for pkg, tests := range pkgs {
+		if rootPkg != "" {
+			pkg = path.Join(rootPkg, pkg)
+		}
 		pm := make(map[string]bool)
 		for _, test := range tests {
 			fields := strings.Fields(test)

--- a/gotestskip.go
+++ b/gotestskip.go
@@ -29,8 +29,19 @@ format:
 	somerepo.com/pkg1:
 	-TestZ 2022-03-04
 
-The top level key is the package to skip tests of. Each
+The top level key specifies a package in which to skip tests. Each
 value inside that specifies a test to skip. Skipping a test will skip all its subtests too.
+
+If $GO_SKIP_ROOT is set, it's used as the prefix for package names.
+So if GO_SKIP_ROOT is set to "somerepo.com", the
+above configuration can be specified as:
+
+	pkg0:
+	-TestX/subtest
+	-TestX/othertest
+	-TestY
+	pkg1:
+	-TestZ 2022-03-04
 
 Note that even when a test is marked to be skipped, it will still actually
 run - just any failure will cause the test to be marked as skipped rather
@@ -100,7 +111,7 @@ func mainErr() error {
 		}
 		return nil
 	}
-	skip, err := readSkipConfig(skipFile)
+	skip, err := readSkipConfig(skipFile, os.Getenv("GO_SKIP_ROOT"))
 	if err != nil {
 		return err
 	}

--- a/testdata/with-root.txt
+++ b/testdata/with-root.txt
@@ -1,0 +1,22 @@
+
+env GO_SKIP_TESTS=skip.yaml
+env GO_SKIP_ROOT=example.com
+gotestskip -p 1 ./...
+
+-- skip.yaml --
+m:
+- TestFoo/bar
+-- go.mod --
+module example.com/m
+
+go 1.18
+-- tst_test.go --
+package m_test
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	t.Run("bar", func(t *testing.T) {
+		t.Errorf("an error")
+	})
+}


### PR DESCRIPTION
This allows the skip config to be somewhat more concise in the
common case that all the tests are below a specific package root.